### PR TITLE
Refactor multi-channel reminder templating

### DIFF
--- a/src/lib/reminders/multi-channel-reminder-service.ts
+++ b/src/lib/reminders/multi-channel-reminder-service.ts
@@ -1,242 +1,213 @@
 import { sendEmail } from '@/lib/email'
 import { sendPulseWhatsAppClient } from '@/lib/sendpulse-whatsapp'
+import {
+  buildEmailReminderContent,
+  buildWhatsAppReminderContent
+} from '@/lib/reminders/reminder-templates'
+import {
+  type NotificationChannel,
+  type ReminderMessage,
+  type ReminderRecipient
+} from '@/lib/reminders/reminder-types'
 
-export type NotificationChannel = 'EMAIL' | 'WHATSAPP' | 'BOTH'
-export type ReminderType = 'subscription_renewal' | 'order_delivery' | 'appointment' | 'general'
+type DeliveryChannel = Exclude<NotificationChannel, 'BOTH'>
 
-export interface ReminderRecipient {
-  userId: string
-  email: string
-  phone?: string
-  name?: string
-  preferredChannel?: NotificationChannel
+const MAX_DELIVERY_ATTEMPTS = 2
+
+export class ReminderDeliveryError extends Error {
+  constructor(
+    public readonly channel: DeliveryChannel,
+    public readonly provider: string,
+    public readonly cause: unknown
+  ) {
+    super(`Failed to deliver reminder via ${channel}`)
+  }
 }
 
-export interface ReminderMessage {
-  type: ReminderType
-  subject?: string
-  message: string
-  metadata?: Record<string, any>
+export interface ChannelDeliveryResult {
+  success: boolean
+  attempts: number
+  error?: ReminderDeliveryError
+}
+
+export interface ReminderDeliverySummary {
+  email: boolean
+  whatsapp: boolean
+  details: Record<DeliveryChannel, ChannelDeliveryResult>
+  errors: ReminderDeliveryError[]
 }
 
 export class MultiChannelReminderService {
   async sendReminder(
     recipient: ReminderRecipient,
     reminder: ReminderMessage
-  ): Promise<{ email: boolean; whatsapp: boolean }> {
-    const channel = recipient.preferredChannel || 'EMAIL'
-    const results = { email: false, whatsapp: false }
-
-    if (channel === 'EMAIL' || channel === 'BOTH') {
-      results.email = await this.sendEmailReminder(recipient, reminder)
+  ): Promise<ReminderDeliverySummary> {
+    const { channels, errors: resolutionErrors } = this.resolveChannels(recipient)
+    const details: Record<DeliveryChannel, ChannelDeliveryResult> = {
+      EMAIL: { success: false, attempts: 0 },
+      WHATSAPP: { success: false, attempts: 0 }
     }
+    const errors = [...resolutionErrors]
 
-    if (channel === 'WHATSAPP' || channel === 'BOTH') {
-      if (recipient.phone) {
-        results.whatsapp = await this.sendWhatsAppReminder(recipient, reminder)
+    for (const channel of channels) {
+      const result = await this.dispatchChannel(channel, recipient, reminder)
+      details[channel] = result
+      if (result.error) {
+        errors.push(result.error)
       }
     }
 
-    return results
+    return {
+      email: details.EMAIL.success,
+      whatsapp: details.WHATSAPP.success,
+      details,
+      errors
+    }
   }
 
-  private async sendEmailReminder(
+  private async dispatchChannel(
+    channel: DeliveryChannel,
     recipient: ReminderRecipient,
     reminder: ReminderMessage
-  ): Promise<boolean> {
-    try {
-      const html = this.formatEmailContent(recipient, reminder)
-      const subject = reminder.subject || this.getDefaultSubject(reminder.type)
+  ): Promise<ChannelDeliveryResult> {
+    if (channel === 'EMAIL') {
+      return this.attemptDelivery(channel, () => this.deliverEmail(recipient, reminder))
+    }
 
-      const result = await sendEmail({
+    return this.attemptDelivery(channel, () => this.deliverWhatsApp(recipient, reminder))
+  }
+
+  private async attemptDelivery(
+    channel: DeliveryChannel,
+    operation: () => Promise<void>
+  ): Promise<ChannelDeliveryResult> {
+    let attempts = 0
+    let lastError: ReminderDeliveryError | undefined
+
+    while (attempts < MAX_DELIVERY_ATTEMPTS) {
+      attempts += 1
+      try {
+        await operation()
+        return { success: true, attempts }
+      } catch (error) {
+        lastError =
+          error instanceof ReminderDeliveryError
+            ? error
+            : new ReminderDeliveryError(channel, 'unknown', error)
+
+        if (attempts < MAX_DELIVERY_ATTEMPTS) {
+          const backoffDelay = attempts * 250
+          await new Promise((resolve) => setTimeout(resolve, backoffDelay))
+        }
+      }
+    }
+
+    if (lastError) {
+      console.error(`[ReminderDelivery:${channel}]`, lastError)
+    }
+
+    return {
+      success: false,
+      attempts,
+      error: lastError
+    }
+  }
+
+  private async deliverEmail(recipient: ReminderRecipient, reminder: ReminderMessage): Promise<void> {
+    try {
+      const { subject, html } = buildEmailReminderContent({ recipient, reminder })
+      const response = await sendEmail({
         to: recipient.email,
         subject,
         html
       })
 
-      return result && 'id' in result
+      if (!response || typeof response !== 'object' || !('id' in response)) {
+        throw new ReminderDeliveryError(
+          'EMAIL',
+          'Transactional Email',
+          new Error('Email provider returned an unexpected response')
+        )
+      }
     } catch (error) {
-      console.error('Email reminder send failed:', error)
-      return false
+      throw error instanceof ReminderDeliveryError
+        ? error
+        : new ReminderDeliveryError('EMAIL', 'Transactional Email', error)
     }
   }
 
-  private async sendWhatsAppReminder(
+  private async deliverWhatsApp(
     recipient: ReminderRecipient,
     reminder: ReminderMessage
-  ): Promise<boolean> {
+  ): Promise<void> {
+    if (!recipient.phone) {
+      throw new ReminderDeliveryError(
+        'WHATSAPP',
+        'SendPulse WhatsApp',
+        new Error('Recipient phone number is required for WhatsApp reminders')
+      )
+    }
+
     try {
-      if (!recipient.phone) {
-        throw new Error('Phone number required for WhatsApp reminders')
-      }
-
-      const whatsappMessage = this.formatWhatsAppMessage(recipient, reminder)
-
-      const result = await sendPulseWhatsAppClient.sendMessage({
+      const text = buildWhatsAppReminderContent({ recipient, reminder })
+      const response = await sendPulseWhatsAppClient.sendMessage({
         phone: recipient.phone,
-        text: whatsappMessage
+        text
       })
 
-      return result?.success === true
+      if (!response || response.success !== true) {
+        throw new ReminderDeliveryError(
+          'WHATSAPP',
+          'SendPulse WhatsApp',
+          new Error('WhatsApp provider returned an unsuccessful response')
+        )
+      }
     } catch (error) {
-      console.error('WhatsApp reminder send failed:', error)
-      return false
+      throw error instanceof ReminderDeliveryError
+        ? error
+        : new ReminderDeliveryError('WHATSAPP', 'SendPulse WhatsApp', error)
     }
   }
 
-  private formatWhatsAppMessage(
-    recipient: ReminderRecipient,
-    reminder: ReminderMessage
-  ): string {
-    const greeting = recipient.name ? `Olá, ${recipient.name}!` : 'Olá!'
-    const icon = this.getReminderIcon(reminder.type)
+  private resolveChannels(
+    recipient: ReminderRecipient
+  ): { channels: DeliveryChannel[]; errors: ReminderDeliveryError[] } {
+    const preference = recipient.preferredChannel ?? 'EMAIL'
+    const channels = new Set<DeliveryChannel>()
+    const errors: ReminderDeliveryError[] = []
 
-    let message = `${icon} *SV Lentes - Lembrete*\n\n`
-    message += `${greeting}\n\n`
-    message += `${reminder.message}\n\n`
-    
-    if (reminder.type === 'subscription_renewal') {
-      message += `📱 *Precisa de ajuda?*\n`
-      message += `Responda esta mensagem ou acesse:\n`
-      message += `https://svlentes.com.br/area-usuario\n\n`
-    } else if (reminder.type === 'order_delivery') {
-      message += `📦 *Rastreie seu pedido:*\n`
-      message += `https://svlentes.com.br/area-usuario?tab=pedidos\n\n`
+    if (preference === 'EMAIL' || preference === 'BOTH') {
+      channels.add('EMAIL')
     }
 
-    message += `_SV Lentes - Lentes de Contato com Acompanhamento Médico_`
-
-    return message
-  }
-
-  private formatEmailContent(
-    recipient: ReminderRecipient,
-    reminder: ReminderMessage
-  ): string {
-    const greetingName = recipient.name || 'Cliente'
-    const icon = this.getReminderIcon(reminder.type)
-
-    return `
-      <!DOCTYPE html>
-      <html lang="pt-BR">
-      <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Lembrete - SV Lentes</title>
-      </head>
-      <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #f5f5f5;">
-        
-        <div style="background: linear-gradient(135deg, #06b6d4 0%, #0891b2 100%); padding: 30px; text-align: center; border-radius: 10px 10px 0 0;">
-          <h1 style="color: white; margin: 0; font-size: 28px;">SV Lentes</h1>
-          <p style="color: white; margin: 10px 0 0 0; font-size: 16px;">Lentes de Contato com Acompanhamento Médico</p>
-        </div>
-
-        <div style="background: white; padding: 40px 30px; border-radius: 0 0 10px 10px; box-shadow: 0 2px 8px rgba(0,0,0,0.1);">
-          
-          <p style="font-size: 18px; margin-bottom: 20px; color: #0891b2;">
-            Olá, ${greetingName}!
-          </p>
-
-          <div style="background-color: #f0f9ff; border-left: 4px solid #06b6d4; padding: 20px; margin: 25px 0; border-radius: 4px;">
-            <p style="font-size: 16px; margin: 0; color: #0c4a6e; line-height: 1.6;">
-              ${icon} ${reminder.message.replace(/\n/g, '<br>')}
-            </p>
-          </div>
-
-          ${this.renderEmailActionButton(reminder.type)}
-
-          <div style="margin-top: 35px; padding: 20px; background-color: #f8fafc; border-radius: 8px; border: 1px solid #e2e8f0;">
-            <p style="font-size: 14px; color: #64748b; margin: 0 0 10px 0; font-weight: 600;">
-              📞 Precisa de ajuda?
-            </p>
-            <p style="font-size: 14px; color: #64748b; margin: 5px 0;">
-              WhatsApp: <a href="https://wa.me/5533998980026" style="color: #0891b2; text-decoration: none;">(33) 99898-0026</a>
-            </p>
-            <p style="font-size: 14px; color: #64748b; margin: 5px 0;">
-              Email: <a href="mailto:contato@svlentes.com.br" style="color: #0891b2; text-decoration: none;">contato@svlentes.com.br</a>
-            </p>
-          </div>
-
-          <hr style="border: none; border-top: 1px solid #e2e8f0; margin: 30px 0;">
-
-          <div style="text-align: center;">
-            <p style="font-size: 13px; color: #94a3b8; margin: 10px 0;">
-              © 2025 SV Lentes - Dr. Philipe Saraiva Cruz (CRM-MG 69.870)
-            </p>
-            <p style="font-size: 12px; color: #cbd5e1; margin: 15px 0 5px 0;">
-              Você está recebendo este email porque é assinante da SV Lentes.
-              <br><a href="https://svlentes.com.br/area-usuario?tab=preferencias" style="color: #0891b2;">Alterar preferências de notificação</a>
-            </p>
-          </div>
-        </div>
-
-      </body>
-      </html>
-    `
-  }
-
-  private renderEmailActionButton(type: ReminderType): string {
-    const buttons = {
-      subscription_renewal: {
-        text: 'Ver Minha Assinatura',
-        url: 'https://svlentes.com.br/area-usuario?tab=assinatura'
-      },
-      order_delivery: {
-        text: 'Rastrear Pedido',
-        url: 'https://svlentes.com.br/area-usuario?tab=pedidos'
-      },
-      appointment: {
-        text: 'Ver Minhas Consultas',
-        url: 'https://svlentes.com.br/area-usuario?tab=consultas'
-      },
-      general: {
-        text: 'Acessar Minha Conta',
-        url: 'https://svlentes.com.br/area-usuario'
+    if (preference === 'WHATSAPP' || preference === 'BOTH') {
+      if (recipient.phone) {
+        channels.add('WHATSAPP')
+      } else {
+        errors.push(
+          new ReminderDeliveryError(
+            'WHATSAPP',
+            'SendPulse WhatsApp',
+            new Error('Recipient phone number is missing')
+          )
+        )
       }
     }
 
-    const button = buttons[type] || buttons.general
-
-    return `
-      <div style="text-align: center; margin: 30px 0;">
-        <a href="${button.url}"
-           style="background: #06b6d4; color: white; padding: 14px 32px; text-decoration: none; border-radius: 6px; font-weight: 600; display: inline-block; font-size: 16px; box-shadow: 0 2px 4px rgba(6, 182, 212, 0.3);">
-          ${button.text}
-        </a>
-      </div>
-    `
-  }
-
-  private getReminderIcon(type: ReminderType): string {
-    const icons = {
-      subscription_renewal: '🔔',
-      order_delivery: '📦',
-      appointment: '👓',
-      general: '💬'
-    }
-    return icons[type] || icons.general
-  }
-
-  private getDefaultSubject(type: ReminderType): string {
-    const subjects = {
-      subscription_renewal: '🔔 Lembrete: Renovação da sua assinatura SV Lentes',
-      order_delivery: '📦 Seu pedido SV Lentes está a caminho!',
-      appointment: '👓 Lembrete: Consulta de acompanhamento SV Lentes',
-      general: '🔔 Lembrete - SV Lentes'
-    }
-    return subjects[type] || subjects.general
+    return { channels: Array.from(channels), errors }
   }
 
   async sendSubscriptionRenewalReminder(
     recipient: ReminderRecipient,
     daysUntilRenewal: number,
     renewalDate: string
-  ): Promise<{ email: boolean; whatsapp: boolean }> {
-    const message = daysUntilRenewal === 0 
-      ? `Hoje é o dia da renovação da sua assinatura! 🎉\n\nSua próxima entrega será processada automaticamente.`
-      : daysUntilRenewal === 1
-      ? `Amanhã sua assinatura será renovada! 📅\n\nData da renovação: ${renewalDate}\n\nSuas lentes serão enviadas em breve.`
-      : `Faltam apenas ${daysUntilRenewal} dias para a renovação da sua assinatura! 📅\n\nData da renovação: ${renewalDate}\n\nVocê receberá suas lentes no prazo previsto.`
+  ): Promise<ReminderDeliverySummary> {
+    const message =
+      daysUntilRenewal === 0
+        ? 'Hoje é o dia da renovação da sua assinatura! 🎉\n\nSua próxima entrega será processada automaticamente.'
+        : daysUntilRenewal === 1
+        ? `Amanhã sua assinatura será renovada! 📅\n\nData da renovação: ${renewalDate}\n\nSuas lentes serão enviadas em breve.`
+        : `Faltam apenas ${daysUntilRenewal} dias para a renovação da sua assinatura! 📅\n\nData da renovação: ${renewalDate}\n\nVocê receberá suas lentes no prazo previsto.`
 
     return this.sendReminder(recipient, {
       type: 'subscription_renewal',
@@ -252,18 +223,19 @@ export class MultiChannelReminderService {
     recipient: ReminderRecipient,
     trackingCode?: string,
     estimatedDelivery?: string
-  ): Promise<{ email: boolean; whatsapp: boolean }> {
-    let message = `Seu pedido está a caminho! 📦\n\n`
-    
+  ): Promise<ReminderDeliverySummary> {
+    const sections = ['Seu pedido está a caminho! 📦']
+
     if (trackingCode) {
-      message += `Código de rastreio: ${trackingCode}\n\n`
+      sections.push(`Código de rastreio: ${trackingCode}`)
     }
-    
+
     if (estimatedDelivery) {
-      message += `Previsão de entrega: ${estimatedDelivery}\n\n`
+      sections.push(`Previsão de entrega: ${estimatedDelivery}`)
     }
-    
-    message += `Acompanhe seu pedido em tempo real pela sua área de usuário.`
+
+    sections.push('Acompanhe seu pedido em tempo real pela sua área de usuário.')
+    const message = sections.join('\\n\\n')
 
     return this.sendReminder(recipient, {
       type: 'order_delivery',
@@ -279,8 +251,8 @@ export class MultiChannelReminderService {
     recipient: ReminderRecipient,
     appointmentDate: string,
     appointmentTime: string
-  ): Promise<{ email: boolean; whatsapp: boolean }> {
-    const message = `Lembrete de consulta de acompanhamento! 👓\n\nData: ${appointmentDate}\nHorário: ${appointmentTime}\n\nSua saúde ocular é nossa prioridade. Não esqueça de comparecer!`
+  ): Promise<ReminderDeliverySummary> {
+    const message = `Lembrete de consulta de acompanhamento! 👓\\n\\nData: ${appointmentDate}\\nHorário: ${appointmentTime}\\n\\nSua saúde ocular é nossa prioridade. Não esqueça de comparecer!`
 
     return this.sendReminder(recipient, {
       type: 'appointment',

--- a/src/lib/reminders/reminder-templates.ts
+++ b/src/lib/reminders/reminder-templates.ts
@@ -1,0 +1,194 @@
+import type { ReminderMessage, ReminderRecipient, ReminderType } from '@/lib/reminders/reminder-types'
+
+interface TemplateAction {
+  label: string
+  url: string
+}
+
+interface ReminderTemplateDefinition {
+  icon: string
+  defaultSubject: string
+  action: TemplateAction
+  whatsappExtras?: string[][]
+}
+
+const reminderTemplateMap: Record<ReminderType, ReminderTemplateDefinition> = {
+  subscription_renewal: {
+    icon: '🔔',
+    defaultSubject: '🔔 Lembrete: Renovação da sua assinatura SV Lentes',
+    action: {
+      label: 'Ver Minha Assinatura',
+      url: 'https://svlentes.com.br/area-usuario?tab=assinatura'
+    },
+    whatsappExtras: [
+      ['📱 *Precisa de ajuda?*', 'Responda esta mensagem ou acesse:', 'https://svlentes.com.br/area-usuario']
+    ]
+  },
+  order_delivery: {
+    icon: '📦',
+    defaultSubject: '📦 Seu pedido SV Lentes está a caminho!',
+    action: {
+      label: 'Rastrear Pedido',
+      url: 'https://svlentes.com.br/area-usuario?tab=pedidos'
+    },
+    whatsappExtras: [
+      ['📦 *Rastreie seu pedido:*', 'https://svlentes.com.br/area-usuario?tab=pedidos']
+    ]
+  },
+  appointment: {
+    icon: '👓',
+    defaultSubject: '👓 Lembrete: Consulta de acompanhamento SV Lentes',
+    action: {
+      label: 'Ver Minhas Consultas',
+      url: 'https://svlentes.com.br/area-usuario?tab=consultas'
+    },
+    whatsappExtras: [
+      ['💡 *Precisa reagendar?*', 'Responda esta mensagem e nossa equipe cuida de tudo para você.']
+    ]
+  },
+  general: {
+    icon: '💬',
+    defaultSubject: '🔔 Lembrete - SV Lentes',
+    action: {
+      label: 'Acessar Minha Conta',
+      url: 'https://svlentes.com.br/area-usuario'
+    }
+  }
+}
+
+const supportContacts = [
+  {
+    label: 'WhatsApp',
+    value: '(33) 99898-0026',
+    href: 'https://wa.me/5533998980026'
+  },
+  {
+    label: 'Email',
+    value: 'contato@svlentes.com.br',
+    href: 'mailto:contato@svlentes.com.br'
+  }
+]
+
+function getTemplateDefinition(type: ReminderType): ReminderTemplateDefinition {
+  return reminderTemplateMap[type] ?? reminderTemplateMap.general
+}
+
+const htmlEscapeMap: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;'
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => htmlEscapeMap[character] ?? character)
+}
+
+function renderSupportSection(): string {
+  const lines: string[] = []
+  lines.push('<div style="margin-top: 35px; padding: 20px; background-color: #f8fafc; border-radius: 8px; border: 1px solid #e2e8f0;">')
+  lines.push('<p style="font-size: 14px; color: #64748b; margin: 0 0 10px 0; font-weight: 600;">📞 Precisa de ajuda?</p>')
+  for (const contact of supportContacts) {
+    lines.push(
+      `<p style="font-size: 14px; color: #64748b; margin: 5px 0;">${contact.label}: <a href="${contact.href}" style="color: #0891b2; text-decoration: none;">${contact.value}</a></p>`
+    )
+  }
+  lines.push('</div>')
+  return lines.join('')
+}
+
+function renderEmailAction(action: TemplateAction): string {
+  return [
+    '<div style="text-align: center; margin: 30px 0;">',
+    `<a href="${action.url}" style="background: #06b6d4; color: white; padding: 14px 32px; text-decoration: none; border-radius: 6px; font-weight: 600; display: inline-block; font-size: 16px; box-shadow: 0 2px 4px rgba(6, 182, 212, 0.3);">`,
+    action.label,
+    '</a>',
+    '</div>'
+  ].join('')
+}
+
+function renderEmailLayout({
+  greetingName,
+  icon,
+  messageHtml,
+  action
+}: {
+  greetingName: string
+  icon: string
+  messageHtml: string
+  action: TemplateAction
+}): string {
+  const layout: string[] = []
+  layout.push('<!DOCTYPE html>')
+  layout.push('<html lang="pt-BR">')
+  layout.push('<head>')
+  layout.push('<meta charset="UTF-8">')
+  layout.push('<meta name="viewport" content="width=device-width, initial-scale=1.0">')
+  layout.push('<title>Lembrete - SV Lentes</title>')
+  layout.push('</head>')
+  layout.push("<body style=\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #f5f5f5;\">")
+  layout.push('<div style="background: linear-gradient(135deg, #06b6d4 0%, #0891b2 100%); padding: 30px; text-align: center; border-radius: 10px 10px 0 0;">')
+  layout.push('<h1 style="color: white; margin: 0; font-size: 28px;">SV Lentes</h1>')
+  layout.push('<p style="color: white; margin: 10px 0 0 0; font-size: 16px;">Lentes de Contato com Acompanhamento Médico</p>')
+  layout.push('</div>')
+  layout.push('<div style="background: white; padding: 40px 30px; border-radius: 0 0 10px 10px; box-shadow: 0 2px 8px rgba(0,0,0,0.1);">')
+  layout.push(`<p style="font-size: 18px; margin-bottom: 20px; color: #0891b2;">Olá, ${greetingName}!</p>`)
+
+  layout.push('<div style="background-color: #f0f9ff; border-left: 4px solid #06b6d4; padding: 20px; margin: 25px 0; border-radius: 4px;">')
+  layout.push(`<p style="font-size: 16px; margin: 0; color: #0c4a6e; line-height: 1.6;">${icon} ${messageHtml}</p>`)
+  layout.push('</div>')
+  layout.push(renderEmailAction(action))
+  layout.push(renderSupportSection())
+  layout.push('<hr style="border: none; border-top: 1px solid #e2e8f0; margin: 30px 0;">')
+  layout.push('<div style="text-align: center;">')
+  layout.push('<p style="font-size: 13px; color: #94a3b8; margin: 10px 0;">© 2025 SV Lentes - Dr. Philipe Saraiva Cruz (CRM-MG 69.870)</p>')
+  layout.push('<p style="font-size: 12px; color: #cbd5e1; margin: 15px 0 5px 0;">Você está recebendo este email porque é assinante da SV Lentes.<br><a href="https://svlentes.com.br/area-usuario?tab=preferencias" style="color: #0891b2;">Alterar preferências de notificação</a></p>')
+  layout.push('</div>')
+  layout.push('</div>')
+  layout.push('</body>')
+  layout.push('</html>')
+  return layout.join('')
+}
+
+export function buildEmailReminderContent({
+  recipient,
+  reminder
+}: {
+  recipient: ReminderRecipient
+  reminder: ReminderMessage
+}): { subject: string; html: string } {
+  const template = getTemplateDefinition(reminder.type)
+  const greetingName = escapeHtml(recipient.name ?? 'Cliente')
+  const messageHtml = escapeHtml(reminder.message).replace(/\n/g, '<br>')
+  const html = renderEmailLayout({
+    greetingName,
+    icon: template.icon,
+    messageHtml,
+    action: template.action
+  })
+  return {
+    subject: reminder.subject ?? template.defaultSubject,
+    html
+  }
+}
+
+export function buildWhatsAppReminderContent({
+  recipient,
+  reminder
+}: {
+  recipient: ReminderRecipient
+  reminder: ReminderMessage
+}): string {
+  const template = getTemplateDefinition(reminder.type)
+  const greeting = recipient.name ? `Olá, ${recipient.name}!` : 'Olá!'
+  const extraSections = template.whatsappExtras?.map((block) => block.join('\n')) ?? []
+  const sections: string[] = [
+    `${template.icon} *SV Lentes - Lembrete*`,
+    greeting,
+    reminder.message.trim(),
+    ...extraSections,
+    '_SV Lentes - Lentes de Contato com Acompanhamento Médico_'
+  ].filter(Boolean)
+  return sections.join('\n\n')
+}

--- a/src/lib/reminders/reminder-types.ts
+++ b/src/lib/reminders/reminder-types.ts
@@ -1,0 +1,18 @@
+export type NotificationChannel = 'EMAIL' | 'WHATSAPP' | 'BOTH'
+
+export type ReminderType = 'subscription_renewal' | 'order_delivery' | 'appointment' | 'general'
+
+export interface ReminderRecipient {
+  userId: string
+  email: string
+  phone?: string
+  name?: string
+  preferredChannel?: NotificationChannel
+}
+
+export interface ReminderMessage {
+  type: ReminderType
+  subject?: string
+  message: string
+  metadata?: Record<string, unknown>
+}


### PR DESCRIPTION
## Summary
- extract shared reminder types and reusable channel templates for email and WhatsApp content
- centralize channel routing with retry logic and structured delivery errors
- update reminder workflows to use the new templating and reporting structure

## Testing
- npm run lint *(fails: Cannot find package '@eslint/eslintrc')*
- npm run test *(fails: jest: not found)*
- kluster_code_review_auto *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f21e8c9afc8328a467c5374be3370b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved multi-channel reminder delivery with enhanced error tracking and automatic retry logic.
  * Restructured message routing and delivery pipeline.
  * Centralized reminder template system for consistent email and WhatsApp formatting.

* **Bug Fixes**
  * Better delivery failure reporting with detailed per-channel error information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->