### PR TITLE
Add GA4 funnel tracking and conversion alerts

### DIFF
--- a/src/app/planos/page.tsx
+++ b/src/app/planos/page.tsx
@@ -7,11 +7,29 @@ import { CoverageSection } from '@/components/pricing/CoverageSection';
 import { BenefitsGrid } from '@/components/pricing/BenefitsGrid';
 import { PricingFAQ } from '@/components/pricing/PricingFAQ';
 import { pricingPlans, serviceBenefits, coverageInfo, pricingFAQ } from '@/data/pricing-plans';
+import { trackProductListView, trackProductPageView } from '@/lib/analytics';
 
 export default function PlanosPage() {
   // Set page metadata dynamically using Head or next/head for client components
   React.useEffect(() => {
     document.title = 'Planos de Assinatura de Lentes de Contato | SV Lentes';
+
+    trackProductListView(
+      'planos_page_plans',
+      'Página de Planos',
+      pricingPlans.map((plan) => ({
+        item_id: plan.id,
+        item_name: plan.name,
+        item_category: 'subscription',
+        price: plan.priceMonthly,
+      }))
+    );
+
+    trackProductPageView({
+      item_id: 'planos_page',
+      item_name: 'Planos SV Lentes',
+      item_category: 'subscription',
+    });
   }, []);
   const handleSaibaMais = (planId: string) => {
     // Scroll to FAQ or open modal with plan details

--- a/src/app/success/page.tsx
+++ b/src/app/success/page.tsx
@@ -53,9 +53,11 @@ export default function SuccessPage() {
                 // Track successful conversion
                 trackPaymentCompleted({
                     transactionId: sessionId,
-                    planId: data.session.subscription?.id || 'unknown',
+                    planId: data.session.subscription?.id || 'subscription_success',
+                    planName: data.session.subscription?.id || 'Assinatura SV Lentes',
                     value: data.session.amount_total / 100,
                     currency: 'BRL',
+                    billingInterval: 'monthly',
                     subscriptionId: data.session.subscription?.id,
                 })
             } else {

--- a/src/components/subscription/AddOnsSelector.tsx
+++ b/src/components/subscription/AddOnsSelector.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { Check, Plus, Minus } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
+import { trackEvent } from '@/lib/analytics'
 
 interface AddOn {
     id: string
@@ -69,11 +70,21 @@ export function AddOnsSelector({ onContinue, onBack }: AddOnsSelectorProps) {
     const [selectedAddOns, setSelectedAddOns] = useState<string[]>([])
 
     const toggleAddOn = (addOnId: string) => {
+        const addOn = availableAddOns.find(item => item.id === addOnId)
+
         setSelectedAddOns(prev =>
             prev.includes(addOnId)
                 ? prev.filter(id => id !== addOnId)
                 : [...prev, addOnId]
         )
+
+        if (addOn && !selectedAddOns.includes(addOnId)) {
+            trackEvent('addon_selected', {
+                addon_type: addOn.id,
+                addon_name: addOn.name,
+                addon_price: addOn.price,
+            })
+        }
     }
 
     const calculateTotal = () => {

--- a/src/components/subscription/PlanSelector.tsx
+++ b/src/components/subscription/PlanSelector.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { Check, Star } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { pricingPlans } from '@/data/pricing-plans'
+import { trackPlanSelection } from '@/lib/conversion-tracking'
 
 interface PlanSelectorProps {
     onSelectPlan: (planId: string, billingCycle: 'monthly' | 'annual') => void
@@ -17,6 +18,19 @@ export function PlanSelector({ onSelectPlan, initialPlanId }: PlanSelectorProps)
     const handleSelectPlan = (planId: string) => {
         setSelectedPlan(planId)
         onSelectPlan(planId, billingCycle)
+
+        const plan = pricingPlans.find(item => item.id === planId)
+        if (plan) {
+            const price = billingCycle === 'monthly' ? plan.priceMonthly : plan.priceAnnual
+            trackPlanSelection({
+                planId,
+                planName: plan.name,
+                billingInterval: billingCycle,
+                price,
+                planTier: plan.id,
+                quantity: 1,
+            })
+        }
     }
 
     return (


### PR DESCRIPTION
## Summary
- add GA4 helper events for product views, cart changes, checkout lifecycle, and conversion rate telemetry
- track funnel stage statistics with alerting on >20% conversion drops and propagate metrics to monitoring
- instrument plan listings and subscription flow to emit GA4 events for views, add-to-cart, checkout completion, and payment failures

## Testing
- npm run lint *(fails: repository has pre-existing lint errors and warnings across many files)*
- npm run test *(fails: repository has multiple existing failing test suites)*
- npm run build *(fails: build lint step reports numerous existing warnings treated as errors)*

------
https://chatgpt.com/codex/tasks/task_e_68f42697f93083289ca02cdf42c36f1b