### PR TITLE
Add unit tests for subscription calculators and order forms

### DIFF
--- a/src/components/subscription/__tests__/LensSelector.test.tsx
+++ b/src/components/subscription/__tests__/LensSelector.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { LensSelector } from '../LensSelector'
+
+describe('LensSelector', () => {
+  const setup = () => {
+    const onContinue = jest.fn()
+    const onBack = jest.fn()
+    render(<LensSelector onContinue={onContinue} onBack={onBack} />)
+    return { onContinue, onBack }
+  }
+
+  it('shows validation errors for outdated prescription and invalid CRM', async () => {
+    const user = userEvent.setup()
+    setup()
+
+    await user.click(screen.getByText('Acuvue'))
+    const [rightSphere, leftSphere] = screen.getAllByPlaceholderText('-2.00')
+    await user.type(rightSphere, '-2.00')
+    await user.type(leftSphere, '-2.25')
+
+    const outdated = new Date()
+    outdated.setFullYear(outdated.getFullYear() - 2)
+    const outdatedValue = outdated.toISOString().split('T')[0]
+    const dateInput = document.getElementById('prescription-date') as HTMLInputElement
+    fireEvent.change(dateInput, { target: { value: outdatedValue } })
+
+    const crmInput = screen.getByPlaceholderText('123456-MG')
+    await user.type(crmInput, '123456sp')
+
+    expect(await screen.findByText('Prescrição deve ter menos de 1 ano')).toBeInTheDocument()
+    expect(await screen.findByText('Formato inválido (ex: 123456-MG)')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Continuar' })).toBeDisabled()
+  })
+
+  it('enforces axis requirement when cylinder is provided', async () => {
+    const user = userEvent.setup()
+    setup()
+
+    await user.click(screen.getByText('Acuvue'))
+    const [rightSphere, leftSphere] = screen.getAllByPlaceholderText('-2.00')
+    await user.type(rightSphere, '-2.00')
+    await user.type(leftSphere, '-2.25')
+
+    const [rightCylinder] = screen.getAllByPlaceholderText('-0.75')
+    await user.type(rightCylinder, '-1.25')
+
+    expect(await screen.findByText('Necessário quando há cilíndrico')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Continuar' })).toBeDisabled()
+
+    const [rightAxis] = screen.getAllByPlaceholderText('180')
+    await user.type(rightAxis, '90')
+
+    expect(screen.queryByText('Necessário quando há cilíndrico')).not.toBeInTheDocument()
+  })
+
+  it('allows advancing with valid mirrored prescription data', async () => {
+    const user = userEvent.setup()
+    const { onContinue } = setup()
+
+    await user.click(screen.getByText('Diárias'))
+    await user.click(screen.getByText('Acuvue'))
+    await user.click(screen.getByRole('button', { name: 'Mesmo grau para ambos' }))
+
+    const [rightSphere] = screen.getAllByPlaceholderText('-2.00')
+    await user.type(rightSphere, '-2.00')
+
+    const validDate = new Date()
+    validDate.setMonth(validDate.getMonth() - 3)
+    const validValue = validDate.toISOString().split('T')[0]
+    const dateInput = document.getElementById('prescription-date') as HTMLInputElement
+    fireEvent.change(dateInput, { target: { value: validValue } })
+
+    const crmInput = screen.getByPlaceholderText('123456-MG')
+    await user.type(crmInput, '123456-SP')
+
+    const continueButton = screen.getByRole('button', { name: 'Continuar' })
+    expect(continueButton).toBeEnabled()
+
+    await user.click(continueButton)
+
+    expect(onContinue).toHaveBeenCalledTimes(1)
+    expect(onContinue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'daily',
+        brand: 'Acuvue',
+        rightEye: expect.objectContaining({ sphere: '-2.00' }),
+        leftEye: expect.objectContaining({ sphere: '-2.00' }),
+        prescriptionDate: validValue,
+        doctorCRM: '123456-SP',
+      }),
+    )
+  })
+})

--- a/src/components/subscription/__tests__/OrderSummary.test.tsx
+++ b/src/components/subscription/__tests__/OrderSummary.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { OrderSummary } from '../OrderSummary'
+import { type LensData } from '@/types/subscription'
+
+jest.mock('@/config/loader', () => ({
+  config: {
+    load: jest.fn(() => ({
+      featureFlags: { useCentralizedPricing: true },
+      pricing: {
+        plans: [
+          {
+            id: 'basico',
+            name: 'Plano Básico',
+            badge: 'Mock',
+            priceMonthly: 89,
+            priceAnnual: 1068,
+            description: 'Mock plan',
+            features: [],
+            recommended: false,
+            stripeProductId: 'mock',
+            stripePriceId: 'mock',
+            asaasProductId: 'mock',
+            ctaText: 'Mock',
+          },
+        ],
+        featureComparison: { features: [], planComparison: [] },
+      },
+    })),
+    isFeatureEnabled: jest.fn(() => true),
+  },
+}))
+
+const baseLensData: LensData = {
+  type: 'monthly',
+  brand: 'Acuvue',
+  rightEye: { sphere: '-1.50', cylinder: '', axis: '' },
+  leftEye: { sphere: '-1.25', cylinder: '', axis: '' },
+}
+
+describe('OrderSummary', () => {
+  const createProps = () => ({
+    planId: 'basico',
+    billingCycle: 'monthly' as const,
+    lensData: baseLensData,
+    addOns: ['solution', 'express'],
+    onBack: jest.fn(),
+    onConfirm: jest.fn(),
+  })
+
+  it('renders plan details and totals with add-ons', () => {
+    render(<OrderSummary {...createProps()} />)
+
+    expect(screen.getByText('Plano Selecionado')).toBeInTheDocument()
+    expect(screen.getByText('Plano Básico')).toBeInTheDocument()
+    expect(screen.getByText('Serviços Adicionais')).toBeInTheDocument()
+    expect(screen.getByText('+R$ 25')).toBeInTheDocument()
+    expect(screen.getByText('+R$ 30')).toBeInTheDocument()
+    expect(screen.getAllByText('R$ 89.00')).not.toHaveLength(0)
+    expect(screen.getAllByText('R$ 55.00')).not.toHaveLength(0)
+    expect(screen.getByText('R$ 144.00')).toBeInTheDocument()
+  })
+
+  it('applies masks to phone and CPF fields as the user types', async () => {
+    const user = userEvent.setup()
+    render(<OrderSummary {...createProps()} />)
+
+    const phoneInput = screen.getByPlaceholderText('(11) 99999-9999')
+    const documentInput = screen.getByPlaceholderText('000.000.000-00')
+
+    await user.type(phoneInput, '11987654321')
+    await user.type(documentInput, '52998224725')
+
+    expect(phoneInput).toHaveValue('(11) 98765-4321')
+    expect(documentInput).toHaveValue('529.982.247-25')
+  })
+
+  it('displays validation feedback for invalid email on blur', async () => {
+    const user = userEvent.setup()
+    render(<OrderSummary {...createProps()} />)
+
+    const emailInput = screen.getByPlaceholderText('joao@email.com')
+    await user.type(emailInput, 'invalid-email')
+    fireEvent.blur(emailInput)
+
+    expect(await screen.findByText('Email inválido')).toBeInTheDocument()
+  })
+
+  it('collects sanitized contact data in form state', async () => {
+    const user = userEvent.setup()
+    const onConfirm = jest.fn()
+    render(<OrderSummary {...createProps()} onConfirm={onConfirm} />)
+
+    await user.type(screen.getByPlaceholderText('João Silva'), 'Maria Souza')
+    await user.type(screen.getByPlaceholderText('(11) 99999-9999'), '11987654321')
+    await user.type(screen.getByPlaceholderText('joao@email.com'), 'maria@souza.com')
+    await user.type(screen.getByPlaceholderText('000.000.000-00'), '52998224725')
+
+    const paymentSelect = screen.getByRole('combobox')
+    await user.selectOptions(paymentSelect, 'BOLETO')
+
+    const checkboxes = screen.getAllByRole('checkbox')
+    for (const checkbox of checkboxes) {
+      await user.click(checkbox)
+      expect((checkbox as HTMLInputElement).checked).toBe(true)
+    }
+
+    expect(screen.getByPlaceholderText('João Silva')).toHaveValue('Maria Souza')
+    expect(screen.getByPlaceholderText('(11) 99999-9999')).toHaveValue('(11) 98765-4321')
+    expect(screen.getByPlaceholderText('joao@email.com')).toHaveValue('maria@souza.com')
+    expect(screen.getByPlaceholderText('000.000.000-00')).toHaveValue('529.982.247-25')
+    expect(screen.getByRole('combobox')).toHaveValue('BOLETO')
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/__tests__/calculator.test.ts
+++ b/src/lib/__tests__/calculator.test.ts
@@ -1,0 +1,105 @@
+import {
+  calculateEconomy,
+  formatCurrency,
+  formatPercentage,
+  validateCalculatorInput,
+  type UnifiedCalculatorInput,
+} from '../calculator'
+
+describe('calculateEconomy', () => {
+  const baseInput: UnifiedCalculatorInput = {
+    lensType: 'daily',
+    usagePattern: 'regular',
+  }
+
+  it('computes savings metrics for valid inputs', () => {
+    const result = calculateEconomy(baseInput)
+
+    expect(result.lensesPerMonth).toBe(40)
+    expect(result.monthlyAvulso).toBeCloseTo(180)
+    expect(result.monthlySubscription).toBeCloseTo(108)
+    expect(result.monthlySavings).toBeCloseTo(72)
+    expect(result.yearlyAvulso).toBeCloseTo(2160)
+    expect(result.yearlySubscription).toBeCloseTo(1296)
+    expect(result.yearlySavings).toBeCloseTo(864)
+    expect(result.savingsPercentage).toBeCloseTo(40)
+    expect(result.recommendedPlan).toBe('premium')
+    expect(result.totalCurrentAnnualCost).toBeCloseTo(2560)
+    expect(result.totalSVLentesAnnualCost).toBeCloseTo(3094.8)
+    expect(result.totalAnnualSavings).toBeCloseTo(-534.8)
+    expect(result.includedConsultations).toBe(2)
+    expect(result.costPerLens).toEqual({ current: 4.5, subscription: 2.7 })
+  })
+
+  it('incorporates provided annual spending details', () => {
+    const result = calculateEconomy({
+      lensType: 'weekly',
+      usagePattern: 'daily',
+      annualContactLensCost: 4800,
+      annualConsultationCost: 600,
+    })
+
+    expect(result.lensesPerMonth).toBe(60)
+    expect(result.totalCurrentAnnualCost).toBe(5400)
+    expect(result.totalSVLentesAnnualCost).toBeCloseTo(6982.8)
+    expect(result.totalAnnualSavings).toBeCloseTo(-1582.8)
+  })
+
+  it('throws when lens configuration is invalid', () => {
+    expect(() =>
+      calculateEconomy({ lensType: 'daily', usagePattern: 'invalid' as any })
+    ).toThrow('Padrão de uso ou tipo de lente inválido')
+  })
+})
+
+describe('format helpers', () => {
+  it('formats currency using Brazilian locale', () => {
+    expect(formatCurrency(1234.56)).toBe('R$\u00a01.234,56')
+    expect(formatCurrency(-50)).toBe('-R$\u00a050,00')
+  })
+
+  it('rounds percentage values', () => {
+    expect(formatPercentage(37.2)).toBe('37%')
+    expect(formatPercentage(37.8)).toBe('38%')
+  })
+})
+
+describe('validateCalculatorInput', () => {
+  it('accepts complete valid payload', () => {
+    const result = validateCalculatorInput({
+      lensType: 'daily',
+      usagePattern: 'regular',
+      currentSpending: 200,
+    })
+
+    expect(result).toEqual({ isValid: true, errors: [] })
+  })
+
+  it('collects errors for missing mandatory fields', () => {
+    const result = validateCalculatorInput({})
+
+    expect(result.isValid).toBe(false)
+    expect(result.errors).toEqual([
+      'Tipo de lente é obrigatório',
+      'Padrão de uso é obrigatório',
+    ])
+  })
+
+  it('validates spending boundaries', () => {
+    const negative = validateCalculatorInput({
+      lensType: 'daily',
+      usagePattern: 'regular',
+      currentSpending: -10,
+    })
+    expect(negative.isValid).toBe(false)
+    expect(negative.errors).toContain('Gasto atual não pode ser negativo')
+
+    const veryHigh = validateCalculatorInput({
+      lensType: 'daily',
+      usagePattern: 'regular',
+      currentSpending: 1500,
+    })
+    expect(veryHigh.isValid).toBe(false)
+    expect(veryHigh.errors).toContain('Gasto atual parece muito alto, verifique o valor')
+  })
+})

--- a/src/lib/__tests__/formatters.test.ts
+++ b/src/lib/__tests__/formatters.test.ts
@@ -1,0 +1,34 @@
+import {
+  formatCurrency,
+  formatDate,
+  formatDateLong,
+  formatPhone,
+  formatZipCode,
+} from '../formatters'
+
+describe('formatters', () => {
+  it('formats short and long dates in pt-BR locale', () => {
+    const date = new Date('2024-05-20T12:00:00Z')
+
+    expect(formatDate(date)).toBe('20/05/2024')
+    expect(formatDate('2024-05-20T12:00:00Z')).toBe('20/05/2024')
+    expect(formatDateLong(date)).toBe('20 de maio de 2024')
+  })
+
+  it('formats currency respecting locale rules', () => {
+    expect(formatCurrency(0)).toBe('R$\u00a00,00')
+    expect(formatCurrency(199.9)).toBe('R$\u00a0199,90')
+  })
+
+  it('formats Brazilian phone numbers when possible', () => {
+    expect(formatPhone('11987654321')).toBe('(11) 98765-4321')
+    expect(formatPhone('(21)33334444')).toBe('(21) 3333-4444')
+    expect(formatPhone('123')).toBe('123')
+  })
+
+  it('formats CEP codes', () => {
+    expect(formatZipCode('12345678')).toBe('12345-678')
+    expect(formatZipCode('12345-678')).toBe('12345-678')
+    expect(formatZipCode('1234')).toBe('1234')
+  })
+})


### PR DESCRIPTION
## Summary
- add coverage for calculator utilities to verify economy math, percentage formatting, and validation branches
- add formatter tests for shared date, currency, phone, and CEP helpers
- add subscription order form tests covering masking, validation feedback, and prescription selector flows

## Testing
- npm run test -- src/lib/__tests__/calculator.test.ts
- npm run test -- src/lib/__tests__/formatters.test.ts
- npm run test -- src/components/subscription/__tests__/LensSelector.test.tsx
- npm run test -- src/components/subscription/__tests__/OrderSummary.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68f428cfda2c8328a08f6a1a5cac10a6