### PR TITLE
Fix CodeRabbit knowledge base indentation

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -95,12 +95,12 @@ path_instructions:
       - Data integrity constraints
       - LGPD compliance (data retention, deletion)
 
-  # Knowledge base for domain-specific context
-  knowledge_base:
-    code_guidelines:
-      enabled: true
-      filePatterns:
-        - "docs/CODERABBIT_KNOWLEDGE_BASE.md"
+# Knowledge base for domain-specific context
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "docs/CODERABBIT_KNOWLEDGE_BASE.md"
 
 # Enable specific review features
 enable:


### PR DESCRIPTION
## Summary
- correct the indentation of the knowledge_base section in .coderabbit.yaml so it parses properly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7758628b48328ae604fc2241f610b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeRabbit configuration file formatting and organization for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->